### PR TITLE
feat: fixed definiton of maxDepth

### DIFF
--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -16,7 +16,7 @@ var statsCmd = &cobra.Command{
 	Short: "Shows metrics about dependency chains",
 	Long: `Provides the following metrics:
 	1. Total Dependencies: Total number of dependencies of the project
-	2. Max Depth of Dependencies: Length of the longest dependency chain
+	2. Max Depth of Dependencies: Number of dependencies in the longest dependency chain
 	3. Transitive Dependencies: Total number of transitive dependencies (dependencies which are not direct dependencies of the project)`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		depGraph, deps, mainModule := getDepInfo()
@@ -50,9 +50,7 @@ var statsCmd = &cobra.Command{
 		// print the longest chain
 		if verbose {
 			fmt.Println("Longest chain is: ")
-			// maxDepth + 1 since maxDepth stores length of longest
-			// chain and chains has number of deps in chain as keys
-			printChain(chains[maxDepth+1])
+			printChain(chains[maxDepth])
 		}
 
 		if jsonOutput {
@@ -82,8 +80,8 @@ func getMaxDepth(chains map[int][]string) int {
 	for deps := range chains {
 		maxDeps = max(maxDeps, deps)
 	}
-	// for A -> B -> C the depth is 2
-	return maxDeps - 1
+	// for A -> B -> C the depth is 3
+	return maxDeps
 }
 
 func init() {

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -38,13 +38,13 @@ func Test_getChains_simple(t *testing.T) {
 		t.Errorf("There should be no cycles")
 	}
 
-	if maxDepth != 4 {
+	if maxDepth != 5 {
 		t.Errorf("Max depth of dependencies was incorrect")
 	}
 
 	longestPath := []string{"A", "C", "E", "F", "H"}
 
-	if !isSliceSame(chains[maxDepth+1], longestPath) {
+	if !isSliceSame(chains[maxDepth], longestPath) {
 		t.Errorf("Longest path was incorrect")
 	}
 }
@@ -90,12 +90,12 @@ func Test_getChains_cycle(t *testing.T) {
 		t.Errorf("Cycle is not correct")
 	}
 
-	if maxDepth != 5 {
+	if maxDepth != 6 {
 		t.Errorf("Max depth of dependencies was incorrect")
 	}
 
 	longestPath := []string{"A", "B", "D", "F", "G", "H"}
-	if !isSliceSame(chains[maxDepth+1], longestPath) {
+	if !isSliceSame(chains[maxDepth], longestPath) {
 		t.Errorf("Longest path was incorrect")
 	}
 }
@@ -131,7 +131,7 @@ func Test_getChains_cycle_2(t *testing.T) {
 
 	cycles := getCycles(cycleChains)
 
-	if maxDepth != 5 {
+	if maxDepth != 6 {
 		t.Errorf("Max depth of dependencies was incorrect")
 	}
 
@@ -155,7 +155,7 @@ func Test_getChains_cycle_2(t *testing.T) {
 	}
 
 	longestPath := []string{"A", "B", "C", "E", "F", "D"}
-	if !isSliceSame(chains[maxDepth+1], longestPath) {
+	if !isSliceSame(chains[maxDepth], longestPath) {
 		t.Errorf("Longest path was incorrect")
 	}
 }


### PR DESCRIPTION
Signed-off-by: RinkiyaKeDad <arshsharma461@gmail.com>

Fixes #18 

Max depth of dependencies now counts the number of dependencies in the longest dependency chain. So for
A -> B -> C
earlier output was 2
now it is 3