### PR TITLE
added pretty printing json, storing all chains, Chains type, module rename, go bump

### DIFF
--- a/cmd/cycles.go
+++ b/cmd/cycles.go
@@ -33,7 +33,7 @@ var cyclesCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		depGraph, _, mainModule := getDepInfo()
 		var cycleChains [][]string
-		chains := make(map[int][]string)
+		chains := make(map[int][][]string)
 		var temp []string
 		getChains(mainModule, depGraph, temp, chains, &cycleChains)
 		cycles := getCycles(cycleChains)
@@ -50,7 +50,7 @@ var cyclesCmd = &cobra.Command{
 			}{
 				Cycles: cycles,
 			}
-			outputRaw, err := json.Marshal(outputObj)
+			outputRaw, err := json.MarshalIndent(outputObj, "", "\t")
 			if err != nil {
 				return err
 			}

--- a/cmd/cycles.go
+++ b/cmd/cycles.go
@@ -32,10 +32,10 @@ var cyclesCmd = &cobra.Command{
 	Long:  `Will show all the cycles in the dependencies of the project.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		depGraph, _, mainModule := getDepInfo()
-		var cycleChains [][]string
-		chains := make(map[int][][]string)
-		var temp []string
-		getChains(mainModule, depGraph, temp, chains, &cycleChains)
+		var cycleChains []Chain
+		var chains []Chain
+		var temp Chain
+		getChains(mainModule, depGraph, temp, &chains, &cycleChains)
 		cycles := getCycles(cycleChains)
 
 		if !jsonOutputCycles {
@@ -46,7 +46,7 @@ var cyclesCmd = &cobra.Command{
 		} else {
 			// create json
 			outputObj := struct {
-				Cycles [][]string `json:"cycles"`
+				Cycles []Chain `json:"cycles"`
 			}{
 				Cycles: cycles,
 			}
@@ -61,22 +61,22 @@ var cyclesCmd = &cobra.Command{
 }
 
 // gets the cycles from the cycleChains
-func getCycles(cycleChains [][]string) [][]string {
-	var cycles [][]string
-	for _, cycle := range cycleChains {
-		var actualCycle []string
+func getCycles(cycleChains []Chain) []Chain {
+	var cycles []Chain
+	for _, chain := range cycleChains {
+		var cycle Chain
 		start := false
-		startDep := cycle[len(cycle)-1]
-		for _, val := range cycle {
+		startDep := chain[len(chain)-1]
+		for _, val := range chain {
 			if val == startDep {
 				start = true
 			}
 			if start {
-				actualCycle = append(actualCycle, val)
+				cycle = append(cycle, val)
 			}
 		}
-		if !sliceContains(cycles, actualCycle) {
-			cycles = append(cycles, actualCycle)
+		if !sliceContains(cycles, cycle) {
+			cycles = append(cycles, cycle)
 		}
 	}
 	return cycles

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -26,11 +26,13 @@ import (
 var jsonOutput bool
 var verbose bool
 
+type Chain []string
+
 // statsCmd represents the statsDeps command
 var statsCmd = &cobra.Command{
 	Use:   "stats",
 	Short: "Shows metrics about dependency chains",
-	Long: `Provides the following metrics:
+	Long: `Provides the following betrics:
 	1. Total Dependencies: Total number of dependencies of the project
 	2. Max Depth of Dependencies: Number of dependencies in the longest dependency chain
 	3. Transitive Dependencies: Total number of transitive dependencies (dependencies which are not direct dependencies of the project)`,
@@ -41,10 +43,10 @@ var statsCmd = &cobra.Command{
 		// also get all cycles
 		// cycleChains stores the chain containing the cycles and
 		// not the actual cycle itself
-		var cycleChains [][]string
-		chains := make(map[int][][]string)
-		var temp []string
-		getChains(mainModule, depGraph, temp, chains, &cycleChains)
+		var cycleChains []Chain
+		var chains []Chain
+		var temp Chain
+		getChains(mainModule, depGraph, temp, &chains, &cycleChains)
 
 		// get values
 		totalDeps := len(deps)
@@ -66,7 +68,7 @@ var statsCmd = &cobra.Command{
 		// print the longest chain
 		if verbose {
 			fmt.Println("Longest chain/s: ")
-			for _, chain := range chains[maxDepth] {
+			for _, chain := range getLongestChains(maxDepth, chains) {
 				printChain(chain)
 			}
 		}
@@ -93,13 +95,23 @@ var statsCmd = &cobra.Command{
 }
 
 // get the length of the longest dependency chain
-func getMaxDepth(chains map[int][][]string) int {
+func getMaxDepth(chains []Chain) int {
 	maxDeps := 0
-	for deps := range chains {
-		maxDeps = max(maxDeps, deps)
+	for _, chain := range chains {
+		maxDeps = max(maxDeps, len(chain))
 	}
 	// for A -> B -> C the depth is 3
 	return maxDeps
+}
+
+func getLongestChains(maxDepth int, chains []Chain) []Chain {
+	var longestChains []Chain
+	for _, chain := range chains {
+		if len(chain) == maxDepth {
+			longestChains = append(longestChains, chain)
+		}
+	}
+	return longestChains
 }
 
 func init() {

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -42,7 +42,7 @@ var statsCmd = &cobra.Command{
 		// cycleChains stores the chain containing the cycles and
 		// not the actual cycle itself
 		var cycleChains [][]string
-		chains := make(map[int][]string)
+		chains := make(map[int][][]string)
 		var temp []string
 		getChains(mainModule, depGraph, temp, chains, &cycleChains)
 
@@ -65,8 +65,10 @@ var statsCmd = &cobra.Command{
 
 		// print the longest chain
 		if verbose {
-			fmt.Println("Longest chain is: ")
-			printChain(chains[maxDepth])
+			fmt.Println("Longest chain/s: ")
+			for _, chain := range chains[maxDepth] {
+				printChain(chain)
+			}
 		}
 
 		if jsonOutput {
@@ -80,7 +82,7 @@ var statsCmd = &cobra.Command{
 				MaxDepth:  maxDepth,
 				TransDeps: transitiveDeps,
 			}
-			outputRaw, err := json.Marshal(outputObj)
+			outputRaw, err := json.MarshalIndent(outputObj, "", "\t")
 			if err != nil {
 				return err
 			}
@@ -91,7 +93,7 @@ var statsCmd = &cobra.Command{
 }
 
 // get the length of the longest dependency chain
-func getMaxDepth(chains map[int][]string) int {
+func getMaxDepth(chains map[int][][]string) int {
 	maxDeps := 0
 	for deps := range chains {
 		maxDeps = max(maxDeps, deps)

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -32,7 +32,7 @@ type Chain []string
 var statsCmd = &cobra.Command{
 	Use:   "stats",
 	Short: "Shows metrics about dependency chains",
-	Long: `Provides the following betrics:
+	Long: `Provides the following metrics:
 	1. Total Dependencies: Total number of dependencies of the project
 	2. Max Depth of Dependencies: Number of dependencies in the longest dependency chain
 	3. Transitive Dependencies: Total number of transitive dependencies (dependencies which are not direct dependencies of the project)`,

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -33,7 +33,7 @@ func max(x, y int) int {
 }
 
 // find all possible chains starting from currentDep
-func getChains(currentDep string, graph map[string][]string, longestPath []string, chains map[int][]string, cycleChains *[][]string) {
+func getChains(currentDep string, graph map[string][]string, longestPath []string, chains map[int][][]string, cycleChains *[][]string) {
 	longestPath = append(longestPath, currentDep)
 	_, ok := graph[currentDep]
 	if ok {
@@ -43,12 +43,12 @@ func getChains(currentDep string, graph map[string][]string, longestPath []strin
 				copy(cpy, longestPath)
 				getChains(dep, graph, cpy, chains, cycleChains)
 			} else {
-				chains[len(longestPath)] = longestPath
+				chains[len(longestPath)] = append(chains[len(longestPath)], longestPath)
 				*cycleChains = append(*cycleChains, append(longestPath, dep))
 			}
 		}
 	} else {
-		chains[len(longestPath)] = longestPath
+		chains[len(longestPath)] = append(chains[len(longestPath)], longestPath)
 	}
 }
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -33,22 +33,24 @@ func max(x, y int) int {
 }
 
 // find all possible chains starting from currentDep
-func getChains(currentDep string, graph map[string][]string, longestPath []string, chains map[int][][]string, cycleChains *[][]string) {
+func getChains(currentDep string, graph map[string][]string, longestPath Chain, chains *[]Chain, cycleChains *[]Chain) {
 	longestPath = append(longestPath, currentDep)
 	_, ok := graph[currentDep]
 	if ok {
 		for _, dep := range graph[currentDep] {
 			if !contains(longestPath, dep) {
-				cpy := make([]string, len(longestPath))
+				cpy := make(Chain, len(longestPath))
 				copy(cpy, longestPath)
 				getChains(dep, graph, cpy, chains, cycleChains)
 			} else {
-				chains[len(longestPath)] = append(chains[len(longestPath)], longestPath)
+				//chains[len(longestPath)] = append(chains[len(longestPath)], longestPath)
+				*chains = append(*chains, longestPath)
 				*cycleChains = append(*cycleChains, append(longestPath, dep))
 			}
 		}
 	} else {
-		chains[len(longestPath)] = append(chains[len(longestPath)], longestPath)
+		*chains = append(*chains, longestPath)
+		//chains[len(longestPath)] = append(chains[len(longestPath)], longestPath)
 	}
 }
 
@@ -135,7 +137,7 @@ func isSliceSame(a, b []string) bool {
 	return true
 }
 
-func sliceContains(val [][]string, key []string) bool {
+func sliceContains(val []Chain, key Chain) bool {
 	for _, v := range val {
 		if isSliceSame(v, key) {
 			return true

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -44,7 +44,7 @@ func Test_getChains_simple(t *testing.T) {
 	graph["F"] = []string{"H"}
 
 	var cycleChains [][]string
-	chains := make(map[int][]string)
+	chains := make(map[int][][]string)
 	var temp []string
 	getChains("A", graph, temp, chains, &cycleChains)
 	maxDepth := getMaxDepth(chains)
@@ -58,10 +58,14 @@ func Test_getChains_simple(t *testing.T) {
 		t.Errorf("Max depth of dependencies was incorrect")
 	}
 
-	longestPath := []string{"A", "C", "E", "F", "H"}
+	longestPath1 := []string{"A", "B", "E", "F", "H"}
+	longestPath2 := []string{"A", "C", "E", "F", "H"}
 
-	if !isSliceSame(chains[maxDepth], longestPath) {
-		t.Errorf("Longest path was incorrect")
+	if !isSliceSame(chains[maxDepth][0], longestPath1) {
+		t.Errorf("First longest path was incorrect")
+	}
+	if !isSliceSame(chains[maxDepth][1], longestPath2) {
+		t.Errorf("Second longest path was incorrect")
 	}
 }
 
@@ -90,7 +94,7 @@ func Test_getChains_cycle(t *testing.T) {
 	graph["H"] = []string{"D"}
 
 	var cycleChains [][]string
-	chains := make(map[int][]string)
+	chains := make(map[int][][]string)
 	var temp []string
 	getChains("A", graph, temp, chains, &cycleChains)
 	maxDepth := getMaxDepth(chains)
@@ -111,7 +115,7 @@ func Test_getChains_cycle(t *testing.T) {
 	}
 
 	longestPath := []string{"A", "B", "D", "F", "G", "H"}
-	if !isSliceSame(chains[maxDepth], longestPath) {
+	if !isSliceSame(chains[maxDepth][0], longestPath) {
 		t.Errorf("Longest path was incorrect")
 	}
 }
@@ -140,7 +144,7 @@ func Test_getChains_cycle_2(t *testing.T) {
 	graph["D"] = []string{"C"}
 
 	var cycleChains [][]string
-	chains := make(map[int][]string)
+	chains := make(map[int][][]string)
 	var temp []string
 	getChains("A", graph, temp, chains, &cycleChains)
 	maxDepth := getMaxDepth(chains)
@@ -171,7 +175,7 @@ func Test_getChains_cycle_2(t *testing.T) {
 	}
 
 	longestPath := []string{"A", "B", "C", "E", "F", "D"}
-	if !isSliceSame(chains[maxDepth], longestPath) {
+	if !isSliceSame(chains[maxDepth][0], longestPath) {
 		t.Errorf("Longest path was incorrect")
 	}
 }

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -43,10 +43,10 @@ func Test_getChains_simple(t *testing.T) {
 	graph["E"] = []string{"F"}
 	graph["F"] = []string{"H"}
 
-	var cycleChains [][]string
-	chains := make(map[int][][]string)
-	var temp []string
-	getChains("A", graph, temp, chains, &cycleChains)
+	var cycleChains []Chain
+	var chains []Chain
+	var temp Chain
+	getChains("A", graph, temp, &chains, &cycleChains)
 	maxDepth := getMaxDepth(chains)
 	cycles := getCycles(cycleChains)
 
@@ -58,13 +58,15 @@ func Test_getChains_simple(t *testing.T) {
 		t.Errorf("Max depth of dependencies was incorrect")
 	}
 
-	longestPath1 := []string{"A", "B", "E", "F", "H"}
-	longestPath2 := []string{"A", "C", "E", "F", "H"}
+	longestPath1 := Chain{"A", "B", "E", "F", "H"}
+	longestPath2 := Chain{"A", "C", "E", "F", "H"}
 
-	if !isSliceSame(chains[maxDepth][0], longestPath1) {
+	longestPaths := getLongestChains(maxDepth, chains)
+
+	if !isSliceSame(longestPaths[0], longestPath1) {
 		t.Errorf("First longest path was incorrect")
 	}
-	if !isSliceSame(chains[maxDepth][1], longestPath2) {
+	if !isSliceSame(longestPaths[1], longestPath2) {
 		t.Errorf("Second longest path was incorrect")
 	}
 }
@@ -93,10 +95,10 @@ func Test_getChains_cycle(t *testing.T) {
 	graph["G"] = []string{"H"}
 	graph["H"] = []string{"D"}
 
-	var cycleChains [][]string
-	chains := make(map[int][][]string)
-	var temp []string
-	getChains("A", graph, temp, chains, &cycleChains)
+	var cycleChains []Chain
+	var chains []Chain
+	var temp Chain
+	getChains("A", graph, temp, &chains, &cycleChains)
 	maxDepth := getMaxDepth(chains)
 	cycles := getCycles(cycleChains)
 
@@ -115,7 +117,8 @@ func Test_getChains_cycle(t *testing.T) {
 	}
 
 	longestPath := []string{"A", "B", "D", "F", "G", "H"}
-	if !isSliceSame(chains[maxDepth][0], longestPath) {
+	longestPaths := getLongestChains(maxDepth, chains)
+	if !isSliceSame(longestPaths[0], longestPath) {
 		t.Errorf("Longest path was incorrect")
 	}
 }
@@ -143,10 +146,10 @@ func Test_getChains_cycle_2(t *testing.T) {
 	graph["F"] = []string{"D"}
 	graph["D"] = []string{"C"}
 
-	var cycleChains [][]string
-	chains := make(map[int][][]string)
-	var temp []string
-	getChains("A", graph, temp, chains, &cycleChains)
+	var cycleChains []Chain
+	var chains []Chain
+	var temp Chain
+	getChains("A", graph, temp, &chains, &cycleChains)
 	maxDepth := getMaxDepth(chains)
 
 	cycles := getCycles(cycleChains)
@@ -175,7 +178,8 @@ func Test_getChains_cycle_2(t *testing.T) {
 	}
 
 	longestPath := []string{"A", "B", "C", "E", "F", "D"}
-	if !isSliceSame(chains[maxDepth][0], longestPath) {
+	longestPaths := getLongestChains(maxDepth, chains)
+	if !isSliceSame(longestPaths[0], longestPath) {
 		t.Errorf("Longest path was incorrect")
 	}
 }
@@ -198,22 +202,22 @@ func Test_isSliceSame_Fail(t *testing.T) {
 }
 
 func Test_sliceContains_Pass(t *testing.T) {
-	var a [][]string
-	a = append(a, []string{"A", "B", "C"})
-	a = append(a, []string{"B", "C"})
-	a = append(a, []string{"C", "A", "B"})
-	b := []string{"B", "C"}
+	var a []Chain
+	a = append(a, Chain{"A", "B", "C"})
+	a = append(a, Chain{"B", "C"})
+	a = append(a, Chain{"C", "A", "B"})
+	b := Chain{"B", "C"}
 	if !sliceContains(a, b) {
 		t.Errorf("Slice a should have b")
 	}
 }
 
 func Test_sliceContains_Fail(t *testing.T) {
-	var a [][]string
-	a = append(a, []string{"A", "B", "C"})
-	a = append(a, []string{"B", "C"})
-	a = append(a, []string{"C", "A", "B"})
-	b := []string{"E", "C"}
+	var a []Chain
+	a = append(a, Chain{"A", "B", "C"})
+	a = append(a, Chain{"B", "C"})
+	a = append(a, Chain{"C", "A", "B"})
+	b := Chain{"E", "C"}
 	if sliceContains(a, b) {
 		t.Errorf("Slice a should not have b")
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
-module github.com/RinkiyaKeDad/depstat
+module github.com/kubernetes-sigs/depstat
 
-go 1.15
+go 1.16
 
 require github.com/spf13/cobra v1.1.1

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package main
 
-import "github.com/RinkiyaKeDad/depstat/cmd"
+import "github.com/kubernetes-sigs/depstat/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
Signed-off-by: RinkiyaKeDad <arshsharma461@gmail.com>

Fixes #26, prerequisite for #24.

- Earlier we were only storing the longest chain of a particular length in a `map[int][]string` but with this PR we will be storing all chains of a particular length in a `map[int][][]string`. This is needed for #24.
- Added tests for this change.
- Pretty printing the JSON output which was a part of [this](https://github.com/kubernetes/repo-infra/pull/236/commits/927e4bab1c729f4a2be5a709bffe57a1c60cb83e) commit was not added to the original depstat repo so I've done that too in this PR.
- Introducing the `Chain` type which is basically a `[]string`.
- Fixed module name in `go.mod` file and import in `main.go`.
- Bumped Go version 1.15 -> 1.16