### PR TITLE
fixed extra line at the end of json output

### DIFF
--- a/cmd/cycles.go
+++ b/cmd/cycles.go
@@ -54,7 +54,7 @@ var cyclesCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			fmt.Println(string(outputRaw))
+			fmt.Print(string(outputRaw))
 		}
 		return nil
 	},

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -88,7 +88,7 @@ var statsCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			fmt.Println(string(outputRaw))
+			fmt.Print(string(outputRaw))
 		}
 		return nil
 	},


### PR DESCRIPTION
Signed-off-by: RinkiyaKeDad <arshsharma461@gmail.com>

Using `Println()` for the JSON output adds an extra line when piping the output to a JSON file. This causes unexpected behaviors since pushing the code to GitHub removes this line but the verify script which runs depstat still expects it. 

Solution: Use `Print()` instead.