### PR TITLE
added version field in root command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,14 +23,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var depstatVersion string
+var DepstatVersion string
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:     "depstat",
 	Short:   "Analyze your Go project's dependencies",
 	Long:    `depstat will help you get details about the dependencies of your Go modules enabled project`,
-	Version: depstatVersion,
+	Version: DepstatVersion,
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
 	//	Run: func(cmd *cobra.Command, args []string) { },

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,9 +25,10 @@ import (
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "depstat",
-	Short: "Analyze your Go project's dependencies",
-	Long:  `depstat will help you get details about the dependencies of your Go modules enabled project`,
+	Use:     "depstat",
+	Short:   "Analyze your Go project's dependencies",
+	Long:    `depstat will help you get details about the dependencies of your Go modules enabled project`,
+	Version: "0.5.3",
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
 	//	Run: func(cmd *cobra.Command, args []string) { },

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,12 +23,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var depstatVersion string
+
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:     "depstat",
 	Short:   "Analyze your Go project's dependencies",
 	Long:    `depstat will help you get details about the dependencies of your Go modules enabled project`,
-	Version: "0.5.3",
+	Version: depstatVersion,
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
 	//	Run: func(cmd *cobra.Command, args []string) { },


### PR DESCRIPTION
Signed-off-by: RinkiyaKeDad <arshsharma461@gmail.com>

Fixes #39 

Running `depstat -v` or `depstat --version` will now print:
```
depstat version v0.5.3
```