### PR TITLE
change metrics shown by stats command

### DIFF
--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"fmt"
 	"io/ioutil"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -106,7 +107,10 @@ func getFileContentsForAllDeps(overview *DependencyOverview) string {
 
 	// color the main module as yellow
 	data := colorMainNode(overview.MainModuleName)
-	for _, dep := range overview.DepList {
+	allDeps := getAllDeps(overview.Graph[overview.MainModuleName], overview.TransDepList)
+	allDeps = append(allDeps, overview.MainModuleName)
+	sort.Strings(allDeps)
+	for _, dep := range allDeps {
 		_, ok := overview.Graph[dep]
 		if !ok {
 			continue

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -31,7 +31,8 @@ var listCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		depGraph := getDepInfo()
 		fmt.Println("List of all dependencies:")
-		printDeps(depGraph.DepList)
+		allDeps := getAllDeps(depGraph.Graph[depGraph.MainModuleName], depGraph.TransDepList)
+		printDeps(allDeps)
 		return nil
 	},
 }

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -45,20 +45,19 @@ var statsCmd = &cobra.Command{
 		getLongestChain(depGraph.MainModuleName, depGraph.Graph, temp, &longestChain)
 
 		// get values
-		totalDeps := len(depGraph.DepList)
 		maxDepth := len(longestChain)
 		directDeps := len(depGraph.Graph[depGraph.MainModuleName])
-		transitiveDeps := totalDeps - directDeps
+		transitiveDeps := len(depGraph.TransDepList)
 
 		if !jsonOutput {
-			fmt.Printf("Total Dependencies: %d \n", totalDeps)
-			fmt.Printf("Max Depth Of Dependencies: %d \n", maxDepth)
+			fmt.Printf("Direct Dependencies: %d \n", directDeps)
 			fmt.Printf("Transitive Dependencies: %d \n", transitiveDeps)
+			fmt.Printf("Max Depth Of Dependencies: %d \n", maxDepth)
 		}
 
 		if verbose {
 			fmt.Println("All dependencies:")
-			printDeps(depGraph.DepList)
+			printDeps(append(depGraph.Graph[depGraph.MainModuleName], depGraph.TransDepList...))
 		}
 
 		// print the longest chain
@@ -70,13 +69,13 @@ var statsCmd = &cobra.Command{
 		if jsonOutput {
 			// create json
 			outputObj := struct {
-				TotalDeps int `json:"totalDependencies"`
-				MaxDepth  int `json:"maxDepthOfDependencies"`
-				TransDeps int `json:"transitiveDependencies"`
+				DirectDeps int `json:"directDependencies"`
+				TransDeps  int `json:"transitiveDependencies"`
+				MaxDepth   int `json:"maxDepthOfDependencies"`
 			}{
-				TotalDeps: totalDeps,
-				MaxDepth:  maxDepth,
-				TransDeps: transitiveDeps,
+				DirectDeps: directDeps,
+				TransDeps:  transitiveDeps,
+				MaxDepth:   maxDepth,
 			}
 			outputRaw, err := json.MarshalIndent(outputObj, "", "\t")
 			if err != nil {

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -47,11 +47,13 @@ var statsCmd = &cobra.Command{
 		// get values
 		maxDepth := len(longestChain)
 		directDeps := len(depGraph.Graph[depGraph.MainModuleName])
+		totalDeps := len(getAllDeps(depGraph.Graph[depGraph.MainModuleName], depGraph.TransDepList))
 		transitiveDeps := len(depGraph.TransDepList)
 
 		if !jsonOutput {
 			fmt.Printf("Direct Dependencies: %d \n", directDeps)
 			fmt.Printf("Transitive Dependencies: %d \n", transitiveDeps)
+			fmt.Printf("Total Dependencies: %d \n", totalDeps)
 			fmt.Printf("Max Depth Of Dependencies: %d \n", maxDepth)
 		}
 
@@ -71,10 +73,12 @@ var statsCmd = &cobra.Command{
 			outputObj := struct {
 				DirectDeps int `json:"directDependencies"`
 				TransDeps  int `json:"transitiveDependencies"`
+				TotalDeps  int `json:"totalDependencies"`
 				MaxDepth   int `json:"maxDepthOfDependencies"`
 			}{
 				DirectDeps: directDeps,
 				TransDeps:  transitiveDeps,
+				TotalDeps:  totalDeps,
 				MaxDepth:   maxDepth,
 			}
 			outputRaw, err := json.MarshalIndent(outputObj, "", "\t")

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -43,10 +44,10 @@ func Test_getChains_simple(t *testing.T) {
 	graph["E"] = []string{"F"}
 	graph["F"] = []string{"H"}
 
-	deps := []string{"A", "B", "C", "D", "E", "F", "H"}
+	transDeps := []string{"E", "G", "F", "H"}
 	overview := &DependencyOverview{
 		Graph:          graph,
-		DepList:           deps,
+		TransDepList:   transDeps,
 		MainModuleName: "A",
 	}
 
@@ -76,7 +77,7 @@ func Test_getChains_simple(t *testing.T) {
 "E" -> "F"
 "F" -> "H"
 `
-
+	fmt.Println(getFileContentsForAllDeps(overview))
 	if correctFileContentsForAllDeps != getFileContentsForAllDeps(overview) {
 		t.Errorf("File contents for graph of all dependencies are wrong")
 	}
@@ -135,10 +136,10 @@ func Test_getChains_cycle(t *testing.T) {
 	graph["G"] = []string{"H"}
 	graph["H"] = []string{"D"}
 
-	deps := []string{"A", "B", "C", "D", "E", "F", "G", "H"}
+	transDeps := []string{"D", "E", "F", "G", "H"}
 	overview := &DependencyOverview{
 		Graph:          graph,
-		DepList:           deps,
+		TransDepList:   transDeps,
 		MainModuleName: "A",
 	}
 
@@ -226,11 +227,11 @@ func Test_getChains_cycle_2(t *testing.T) {
 	graph["F"] = []string{"D"}
 	graph["D"] = []string{"C"}
 
-	deps := []string{"A", "B", "C", "D", "E", "F"}
+	transDeps := []string{"C", "B", "E", "F", "D"}
 
 	overview := &DependencyOverview{
 		Graph:          graph,
-		DepList:           deps,
+		TransDepList:   transDeps,
 		MainModuleName: "A",
 	}
 


### PR DESCRIPTION
Fixes #44 

In addition to total dependencies and transitive dependencies (which were wrongly calculated earlier) the `stats` command now also shows the number of direct dependencies. For more clarification see [this](https://kubernetes.slack.com/archives/CHGFYJVAN/p1625847407188100?thread_ts=1624543295.156300&cid=CHGFYJVAN) slack discussion.





Signed-off-by: RinkiyaKeDad <arshsharma461@gmail.com>