### PR TITLE
Automate release with goreleaser and GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - "*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    if: github.event.base_ref == 'refs/heads/main'
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 depstat
 .DS_Store
 bin
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,34 @@
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    ldflags:
+      - -X github.com/kubernetes-sigs/depstat/cmd.DepstatVersion={{.Version}}
+
+archives:
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+
+checksum:
+  name_template: 'checksums.txt'
+
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,14 @@ depstat is released on an as-needed basis. The process is as follows:
 
 1. An issue proposing a new release with a changelog since the last release is created.
 2. All [OWNERS](OWNERS) must LGTM this release.
-3. An OWNER builds the latest binary with the appropriate tag by running `go build -ldflags "-X main.DepstatVersion=<version-number>"`.
-4. An OWNER uses the GitHub releases page to create a new release and drops the built binaries along with the changelog. 
-5. The release issue is closed.
-6. An announcement email is sent to `kubernetes-dev@googlegroups.com` with the subject `[ANNOUNCE] depstat $VERSION is released`.
+3. An OWNER tags a particular commit that needs to be released using the command - `$ git tag <version-number> <git-commit>`. For example `git tag v0.7.0-rc.2 a56be6f877623913c7322becd29489397203364d`. This commit has to be part of the `main` branch
+4. An OWNER pushes the git tag using `$ git push <git-remote-ref> <tag>`. For example `git push origin v0.7.0-rc.2`
+5. On pushing the git tag, the GitHub Actions [release](https://github.com/kubernetes-sigs/depstat/blob/main/.github/workflows/release.yml) workflow is automatically triggered. The workflow runs [`goreleaser`](https://goreleaser.com/) command to automatically release `depstat` by doing the following automatically:
+    - Building the latest binaries for various platforms (OSes) and architectures and pack them in tar balls
+    - Create a checksums.txt for the tar balls
+    - Find changelog of commits between previous and current release
+    - Create a GitHub release
+    - Upload the tar balls and tar balls to the GitHub release
+    - Add changelog of commits to the GitHub release description
+6. The release issue is closed.
+7. An announcement email is sent to `kubernetes-dev@googlegroups.com` with the subject `[ANNOUNCE] depstat $VERSION is released`.


### PR DESCRIPTION
- Update build command in `RELEASE.md`
- Adds goreleaser config yaml
- Ignore goreleaser's `dist` directory which is used as the build / distribution directory
- Adds GitHub Action workflow config yaml for automatic release using goreleaser on push of git tag
    
Fixes #37

Should I also update the `RELEASE.md` with the information about `goreleaser` and GitHub Actions workflow for automatic release once the repo has a git tag for a given version? I think step 3 and 4 would need some changes - https://github.com/kubernetes-sigs/depstat/blob/main/RELEASE.md to mention that release (building and creating GitHub release) is automated but yeah, the owner can change the changelog for the GitHub release if it's needed

You can look at a sample of the GitHub Actions workflow here - https://github.com/karuppiah7890/depstat/runs/3424475399?check_suite_focus=true

and a sample release here - https://github.com/karuppiah7890/depstat/releases . Particularly - https://github.com/karuppiah7890/depstat/releases/tag/v0.7.0-rc.1 , a dummy RC release

Let me know if we want to split the single commit `automate release process using goreleaser and github actions` into two commits like - `add goreleaser config yaml for automated release` and `add github action workflow config yaml for automated release using goreleaser`

Some things to note
- I'm using most of the defaults of goreleaser config yaml, for example things like `snapshot` config. We can remove it if we think we never need it
  - changelog includes commits, due to the `changelog` config and feature of goreleaser
- I'm using go v1.16 as that's what is being used in `go.mod` and also in the existing GitHub Action workflow. But we can change it if needed to v1.17 as it's already out https://golang.org/dl/
- The build targets are - OSes - Linux, MacOS, Windows. Architectures - arm64 (Not on Windows), x86_64, i386 (Not on Mac) . This comes by default and if we use go v1.17, we will get Windows arm64 too as go v1.17 supports it. Let me know if these targets are good / if they are too much and we can reduce it

Since we have goreleaser config now, with this we can also have a `install.sh` script with the help of [godownloader](https://github.com/goreleaser/godownloader) for automated install. Let me know if we want to add that too, in this PR or separate PR with separate issue for installer script

Also, do we want to publish Docker images? Something to discuss, in case we want to use it in containers. I noticed mention of prow jobs, those run in containers? We can discuss that too in a separate issue or here. GoReleaser supports releasing Docker images it seems