### PR TITLE
update the installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 To install depstat you can run
 
 ```
-go get github.com/kubernetes-sigs/depstat@latest
+go install github.com/kubernetes-sigs/depstat@latest
 ```
 
 ## Usage


### PR DESCRIPTION
Once you install the tool via go get, you will be warned like the following:

```shell
go get: installing executables with 'go get' in module mode is deprecated.
        To adjust and download dependencies of the current module, use 'go get -d'.
        To install using requirements of the current module, use 'go install'.
        To install ignoring the current module, use 'go install' with a version,
        like 'go install example.com/cmd@latest'.
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
go get: added github.com/kubernetes-sigs/depstat v0.6.1
```

So, to avoid that, we can use `install` instead of `get` as recommended above.