### PR TITLE
Add error message feature for cycles.go file,if the command depstat  cycles run with any arguments

### DIFF
--- a/cmd/cycles.go
+++ b/cmd/cycles.go
@@ -31,6 +31,11 @@ var cyclesCmd = &cobra.Command{
 	Short: "Prints cycles in dependency chains.",
 	Long:  `Will show all the cycles in the dependencies of the project.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) != 0 {
+			return fmt.Errorf("cycles does not take any arguments")
+		}
+
 		overview := getDepInfo(nil)
 		var cycleChains []Chain
 		var temp Chain


### PR DESCRIPTION
Add error message feature for cycles.go file,if the command depstat cycles run with any arguments

depstat cycles command  doesn't take any arguments, if it receives
It will throws an error message "cycles does not take arguments"

Signed-off-by: Srinivas Pokala <Pokala.Srinivas@ibm.com>

Fixes(partially) #38 