### PR TITLE
Add diff, why commands and graph enhancements

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -1,0 +1,348 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var dotOutput bool
+
+// DiffStats holds the stats for a single analysis
+type DiffStats struct {
+	DirectDeps int `json:"directDependencies"`
+	TransDeps  int `json:"transitiveDependencies"`
+	TotalDeps  int `json:"totalDependencies"`
+	MaxDepth   int `json:"maxDepthOfDependencies"`
+}
+
+// DiffResult holds the complete diff analysis
+type DiffResult struct {
+	BaseRef      string    `json:"baseRef"`
+	HeadRef      string    `json:"headRef"`
+	Before       DiffStats `json:"before"`
+	After        DiffStats `json:"after"`
+	Delta        DiffStats `json:"delta"`
+	Added        []string  `json:"added"`
+	Removed      []string  `json:"removed"`
+	EdgesAdded   []string  `json:"edgesAdded"`
+	EdgesRemoved []string  `json:"edgesRemoved"`
+}
+
+var diffCmd = &cobra.Command{
+	Use:   "diff <base-ref> [head-ref]",
+	Short: "Compare dependencies between two git refs",
+	Long: `Compare dependency changes between two git commits, branches, or tags.
+
+Examples:
+  # Compare current HEAD with main branch
+  depstat diff main
+
+  # Compare two specific commits
+  depstat diff abc123 def456
+
+  # Output as JSON for CI processing
+  depstat diff main --json
+
+  # Output as DOT format for visualization
+  depstat diff main --dot | dot -Tsvg -o diff.svg`,
+	Args: cobra.RangeArgs(1, 2),
+	RunE: runDiff,
+}
+
+func runDiff(cmd *cobra.Command, args []string) error {
+	baseRef := args[0]
+	headRef := "HEAD"
+	if len(args) > 1 {
+		headRef = args[1]
+	}
+
+	// Save current HEAD to restore later
+	originalRef, err := gitCurrentRef()
+	if err != nil {
+		return fmt.Errorf("failed to get current git ref: %w", err)
+	}
+
+	// Ensure we restore the original state when done
+	defer func() {
+		_ = gitCheckout(originalRef)
+	}()
+
+	// Analyze base ref
+	if err := gitCheckout(baseRef); err != nil {
+		return fmt.Errorf("failed to checkout base ref %s: %w", baseRef, err)
+	}
+	baseDepGraph := getDepInfo(mainModules)
+	baseStats := computeStats(baseDepGraph)
+	baseDeps := getAllDeps(baseDepGraph.DirectDepList, baseDepGraph.TransDepList)
+	baseEdges := getEdges(baseDepGraph.Graph)
+
+	// Analyze head ref
+	if err := gitCheckout(headRef); err != nil {
+		return fmt.Errorf("failed to checkout head ref %s: %w", headRef, err)
+	}
+	headDepGraph := getDepInfo(mainModules)
+	headStats := computeStats(headDepGraph)
+	headDeps := getAllDeps(headDepGraph.DirectDepList, headDepGraph.TransDepList)
+	headEdges := getEdges(headDepGraph.Graph)
+
+	// Compute diff
+	result := DiffResult{
+		BaseRef: baseRef,
+		HeadRef: headRef,
+		Before:  baseStats,
+		After:   headStats,
+		Delta: DiffStats{
+			DirectDeps: headStats.DirectDeps - baseStats.DirectDeps,
+			TransDeps:  headStats.TransDeps - baseStats.TransDeps,
+			TotalDeps:  headStats.TotalDeps - baseStats.TotalDeps,
+			MaxDepth:   headStats.MaxDepth - baseStats.MaxDepth,
+		},
+		Added:        diffSlices(baseDeps, headDeps),
+		Removed:      diffSlices(headDeps, baseDeps),
+		EdgesAdded:   diffSlices(baseEdges, headEdges),
+		EdgesRemoved: diffSlices(headEdges, baseEdges),
+	}
+
+	// Output based on format
+	if jsonOutput {
+		return outputJSON(result)
+	}
+	if dotOutput {
+		return outputDOT(result, baseDepGraph, headDepGraph)
+	}
+	return outputText(result)
+}
+
+func computeStats(depGraph *DependencyOverview) DiffStats {
+	var temp Chain
+	longestChain := getLongestChain(depGraph.MainModules[0], depGraph.Graph, temp, map[string]Chain{})
+	return DiffStats{
+		DirectDeps: len(depGraph.DirectDepList),
+		TransDeps:  len(depGraph.TransDepList),
+		TotalDeps:  len(getAllDeps(depGraph.DirectDepList, depGraph.TransDepList)),
+		MaxDepth:   len(longestChain),
+	}
+}
+
+func getEdges(graph map[string][]string) []string {
+	var edges []string
+	for from, tos := range graph {
+		for _, to := range tos {
+			edges = append(edges, fmt.Sprintf("%s -> %s", from, to))
+		}
+	}
+	sort.Strings(edges)
+	return edges
+}
+
+// diffSlices returns items in b that are not in a
+func diffSlices(a, b []string) []string {
+	aMap := make(map[string]bool)
+	for _, item := range a {
+		aMap[item] = true
+	}
+	var diff []string
+	for _, item := range b {
+		if !aMap[item] {
+			diff = append(diff, item)
+		}
+	}
+	sort.Strings(diff)
+	return diff
+}
+
+func gitCurrentRef() (string, error) {
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func gitCheckout(ref string) error {
+	cmd := exec.Command("git", "checkout", "-q", ref)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func outputJSON(result DiffResult) error {
+	out, err := json.MarshalIndent(result, "", "\t")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(out))
+	return nil
+}
+
+func outputText(result DiffResult) error {
+	fmt.Printf("Dependency Diff: %s..%s\n", result.BaseRef, result.HeadRef)
+	fmt.Println(strings.Repeat("=", 50))
+	fmt.Println()
+
+	// Metrics table
+	fmt.Println("Metrics:")
+	fmt.Println("┌────────────────────┬──────────┬──────────┬─────────┐")
+	fmt.Println("│ Metric             │  Before  │  After   │  Delta  │")
+	fmt.Println("├────────────────────┼──────────┼──────────┼─────────┤")
+	fmt.Printf("│ Direct Deps        │ %8d │ %8d │ %+7d │\n", result.Before.DirectDeps, result.After.DirectDeps, result.Delta.DirectDeps)
+	fmt.Printf("│ Transitive Deps    │ %8d │ %8d │ %+7d │\n", result.Before.TransDeps, result.After.TransDeps, result.Delta.TransDeps)
+	fmt.Printf("│ Total Deps         │ %8d │ %8d │ %+7d │\n", result.Before.TotalDeps, result.After.TotalDeps, result.Delta.TotalDeps)
+	fmt.Printf("│ Max Depth          │ %8d │ %8d │ %+7d │\n", result.Before.MaxDepth, result.After.MaxDepth, result.Delta.MaxDepth)
+	fmt.Println("└────────────────────┴──────────┴──────────┴─────────┘")
+	fmt.Println()
+
+	// Dependencies added
+	fmt.Printf("Dependencies Added (%d):\n", len(result.Added))
+	if len(result.Added) == 0 {
+		fmt.Println("  (none)")
+	} else {
+		for _, dep := range result.Added {
+			fmt.Printf("  + %s\n", dep)
+		}
+	}
+	fmt.Println()
+
+	// Dependencies removed
+	fmt.Printf("Dependencies Removed (%d):\n", len(result.Removed))
+	if len(result.Removed) == 0 {
+		fmt.Println("  (none)")
+	} else {
+		for _, dep := range result.Removed {
+			fmt.Printf("  - %s\n", dep)
+		}
+	}
+	fmt.Println()
+
+	// Edge changes (verbose only)
+	if verbose {
+		fmt.Printf("Edges Added (%d):\n", len(result.EdgesAdded))
+		for _, edge := range result.EdgesAdded {
+			fmt.Printf("  + %s\n", edge)
+		}
+		fmt.Println()
+
+		fmt.Printf("Edges Removed (%d):\n", len(result.EdgesRemoved))
+		for _, edge := range result.EdgesRemoved {
+			fmt.Printf("  - %s\n", edge)
+		}
+	}
+
+	return nil
+}
+
+func outputDOT(result DiffResult, baseGraph, headGraph *DependencyOverview) error {
+	fmt.Println("strict digraph {")
+	fmt.Println("graph [overlap=false, label=\"Dependency Diff: " + result.BaseRef + ".." + result.HeadRef + "\", labelloc=t];")
+	fmt.Println("node [shape=box, style=filled, fillcolor=white];")
+	fmt.Println()
+
+	// Collect all nodes involved in changes
+	changedNodes := make(map[string]string) // node -> status (added/removed/unchanged)
+
+	for _, dep := range result.Added {
+		changedNodes[dep] = "added"
+	}
+	for _, dep := range result.Removed {
+		changedNodes[dep] = "removed"
+	}
+
+	// Add nodes involved in edge changes
+	for _, edge := range result.EdgesAdded {
+		parts := strings.Split(edge, " -> ")
+		if len(parts) == 2 {
+			if changedNodes[parts[0]] == "" {
+				changedNodes[parts[0]] = "unchanged"
+			}
+			if changedNodes[parts[1]] == "" {
+				changedNodes[parts[1]] = "added"
+			}
+		}
+	}
+	for _, edge := range result.EdgesRemoved {
+		parts := strings.Split(edge, " -> ")
+		if len(parts) == 2 {
+			if changedNodes[parts[0]] == "" {
+				changedNodes[parts[0]] = "unchanged"
+			}
+			if changedNodes[parts[1]] == "" {
+				changedNodes[parts[1]] = "removed"
+			}
+		}
+	}
+
+	// Output nodes with colors
+	fmt.Println("// Nodes")
+	for node, status := range changedNodes {
+		color := "white"
+		style := "filled"
+		switch status {
+		case "added":
+			color = "#ccffcc" // green
+		case "removed":
+			color = "#ffcccc" // red
+			style = "filled,dashed"
+		}
+		fmt.Printf("\"%s\" [fillcolor=\"%s\", style=\"%s\"];\n", node, color, style)
+	}
+	fmt.Println()
+
+	// Output removed edges
+	fmt.Println("// Removed edges")
+	for _, edge := range result.EdgesRemoved {
+		parts := strings.Split(edge, " -> ")
+		if len(parts) == 2 {
+			fmt.Printf("\"%s\" -> \"%s\" [color=\"red\", style=\"dashed\", label=\"REMOVED\"];\n", parts[0], parts[1])
+		}
+	}
+	fmt.Println()
+
+	// Output added edges
+	fmt.Println("// Added edges")
+	for _, edge := range result.EdgesAdded {
+		parts := strings.Split(edge, " -> ")
+		if len(parts) == 2 {
+			fmt.Printf("\"%s\" -> \"%s\" [color=\"green\", style=\"bold\", label=\"ADDED\"];\n", parts[0], parts[1])
+		}
+	}
+
+	fmt.Println("}")
+	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(diffCmd)
+	diffCmd.Flags().StringVarP(&dir, "dir", "d", "", "Directory containing the module to evaluate")
+	diffCmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output in JSON format")
+	diffCmd.Flags().BoolVarP(&dotOutput, "dot", "", false, "Output in DOT format for Graphviz")
+	diffCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Include edge-level changes")
+	diffCmd.Flags().StringSliceVarP(&mainModules, "mainModules", "m", []string{}, "Specify main modules")
+}

--- a/cmd/why.go
+++ b/cmd/why.go
@@ -1,0 +1,269 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// WhyPath represents a dependency path from main module to target
+type WhyPath struct {
+	Path   []string `json:"path"`
+	Direct bool     `json:"direct"` // true if this is a direct dependency of a main module
+}
+
+// WhyResult holds the result of why analysis
+type WhyResult struct {
+	Target      string    `json:"target"`
+	Found       bool      `json:"found"`
+	Paths       []WhyPath `json:"paths"`
+	DirectDeps  []string  `json:"directDependents"` // modules that directly depend on target
+	MainModules []string  `json:"mainModules"`
+}
+
+var whyCmd = &cobra.Command{
+	Use:   "why <dependency>",
+	Short: "Show why a dependency is included",
+	Long: `Show all dependency paths from main module(s) to a specific dependency.
+
+This helps understand why a particular dependency exists in your project
+and which modules are pulling it in.
+
+Examples:
+  # Find why a dependency is included
+  depstat why github.com/google/btree
+
+  # Output as JSON
+  depstat why github.com/google/btree --json
+
+  # Output as DOT for visualization
+  depstat why github.com/google/btree --dot | dot -Tsvg -o why.svg`,
+	Args: cobra.ExactArgs(1),
+	RunE: runWhy,
+}
+
+func runWhy(cmd *cobra.Command, args []string) error {
+	target := args[0]
+
+	depGraph := getDepInfo(mainModules)
+
+	// Find all paths to the target
+	result := WhyResult{
+		Target:      target,
+		Found:       false,
+		MainModules: depGraph.MainModules,
+	}
+
+	// Check if target exists in dependencies
+	allDeps := getAllDeps(depGraph.DirectDepList, depGraph.TransDepList)
+	for _, dep := range allDeps {
+		if dep == target {
+			result.Found = true
+			break
+		}
+	}
+
+	if !result.Found {
+		if jsonOutput {
+			return outputWhyJSON(result)
+		}
+		fmt.Printf("Dependency %q not found in the dependency graph.\n", target)
+		return nil
+	}
+
+	// Find all modules that directly depend on target
+	for from, tos := range depGraph.Graph {
+		for _, to := range tos {
+			if to == target {
+				result.DirectDeps = append(result.DirectDeps, from)
+			}
+		}
+	}
+	sort.Strings(result.DirectDeps)
+
+	// Find all paths from main modules to target
+	for _, mainMod := range depGraph.MainModules {
+		paths := findAllPaths(mainMod, target, depGraph.Graph, []string{}, make(map[string]bool))
+		for _, path := range paths {
+			isDirect := len(path) == 2 && contains(depGraph.MainModules, path[0])
+			result.Paths = append(result.Paths, WhyPath{
+				Path:   path,
+				Direct: isDirect,
+			})
+		}
+	}
+
+	// Sort paths by length (shortest first)
+	sort.Slice(result.Paths, func(i, j int) bool {
+		return len(result.Paths[i].Path) < len(result.Paths[j].Path)
+	})
+
+	// Limit paths to avoid overwhelming output
+	maxPaths := 20
+	if len(result.Paths) > maxPaths {
+		result.Paths = result.Paths[:maxPaths]
+	}
+
+	if jsonOutput {
+		return outputWhyJSON(result)
+	}
+	if dotOutput {
+		return outputWhyDOT(result, depGraph)
+	}
+	return outputWhyText(result)
+}
+
+// findAllPaths finds all paths from start to target using DFS
+func findAllPaths(start, target string, graph map[string][]string, currentPath []string, visited map[string]bool) [][]string {
+	currentPath = append(currentPath, start)
+
+	if start == target {
+		// Found the target, return a copy of the path
+		pathCopy := make([]string, len(currentPath))
+		copy(pathCopy, currentPath)
+		return [][]string{pathCopy}
+	}
+
+	if visited[start] {
+		return nil
+	}
+	visited[start] = true
+	defer func() { visited[start] = false }()
+
+	var allPaths [][]string
+	for _, next := range graph[start] {
+		paths := findAllPaths(next, target, graph, currentPath, visited)
+		allPaths = append(allPaths, paths...)
+
+		// Limit search to avoid exponential blowup
+		if len(allPaths) > 100 {
+			break
+		}
+	}
+
+	return allPaths
+}
+
+func outputWhyJSON(result WhyResult) error {
+	out, err := json.MarshalIndent(result, "", "\t")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(out))
+	return nil
+}
+
+func outputWhyText(result WhyResult) error {
+	fmt.Printf("Why is %s included?\n", result.Target)
+	fmt.Println(strings.Repeat("=", 50))
+	fmt.Println()
+
+	if !result.Found {
+		fmt.Println("Not found in dependency graph.")
+		return nil
+	}
+
+	// Show direct dependents
+	fmt.Printf("Directly depended on by (%d modules):\n", len(result.DirectDeps))
+	for _, dep := range result.DirectDeps {
+		marker := "  "
+		if contains(result.MainModules, dep) {
+			marker = "* " // Mark main modules
+		}
+		fmt.Printf("  %s%s\n", marker, dep)
+	}
+	fmt.Println()
+
+	// Show paths
+	fmt.Printf("Dependency paths (showing %d shortest):\n", len(result.Paths))
+	fmt.Println()
+
+	for i, wp := range result.Paths {
+		if wp.Direct {
+			fmt.Printf("  %d. [DIRECT] ", i+1)
+		} else {
+			fmt.Printf("  %d. ", i+1)
+		}
+		fmt.Println(strings.Join(wp.Path, " -> "))
+	}
+
+	if len(result.Paths) == 20 {
+		fmt.Println()
+		fmt.Println("  (showing first 20 paths, use --json for complete list)")
+	}
+
+	return nil
+}
+
+func outputWhyDOT(result WhyResult, depGraph *DependencyOverview) error {
+	fmt.Println("strict digraph {")
+	fmt.Printf("graph [overlap=false, label=\"Why: %s\", labelloc=t];\n", result.Target)
+	fmt.Println("node [shape=box, style=filled, fillcolor=white];")
+	fmt.Println()
+
+	// Collect all nodes and edges from paths
+	nodes := make(map[string]bool)
+	edges := make(map[string]bool)
+
+	for _, wp := range result.Paths {
+		for i, node := range wp.Path {
+			nodes[node] = true
+			if i > 0 {
+				edge := fmt.Sprintf("%s -> %s", wp.Path[i-1], node)
+				edges[edge] = true
+			}
+		}
+	}
+
+	// Output nodes with colors
+	fmt.Println("// Nodes")
+	for node := range nodes {
+		color := "white"
+		if node == result.Target {
+			color = "#ffffcc" // yellow for target
+		} else if contains(result.MainModules, node) {
+			color = "#ccffcc" // green for main modules
+		}
+		fmt.Printf("\"%s\" [fillcolor=\"%s\"];\n", node, color)
+	}
+	fmt.Println()
+
+	// Output edges
+	fmt.Println("// Edges")
+	for edge := range edges {
+		parts := strings.Split(edge, " -> ")
+		if len(parts) == 2 {
+			fmt.Printf("\"%s\" -> \"%s\";\n", parts[0], parts[1])
+		}
+	}
+
+	fmt.Println("}")
+	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(whyCmd)
+	whyCmd.Flags().StringVarP(&dir, "dir", "d", "", "Directory containing the module to evaluate")
+	whyCmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output in JSON format")
+	whyCmd.Flags().BoolVarP(&dotOutput, "dot", "", false, "Output in DOT format for Graphviz")
+	whyCmd.Flags().StringSliceVarP(&mainModules, "mainModules", "m", []string{}, "Specify main modules")
+}


### PR DESCRIPTION
New commands:
- `depstat diff <base> [head]` - Compare dependencies between git refs with text, JSON, and DOT output formats for CI integration
- `depstat why <dep>` - Show all dependency paths to a specific package, helping reviewers understand why a dependency exists

Enhanced graph command:
- `--show-edge-types` flag distinguishes direct (blue/bold) vs transitive (gray/dashed) dependency edges

These features enable better dependency review workflows in CI, showing exactly what changed, which dependencies were added/removed, and visualizing the dependency delta as SVG diagrams.