### PR TITLE
Add -m/--mainModules flag to cycles command

### DIFF
--- a/cmd/cycles.go
+++ b/cmd/cycles.go
@@ -36,7 +36,7 @@ var cyclesCmd = &cobra.Command{
 			return fmt.Errorf("cycles does not take any arguments")
 		}
 
-		overview := getDepInfo(nil)
+		overview := getDepInfo(mainModules)
 		var cycleChains []Chain
 		var temp Chain
 		getCycleChains(overview.MainModules[0], overview.Graph, temp, &cycleChains)
@@ -106,4 +106,5 @@ func getCycles(cycleChains []Chain) []Chain {
 func init() {
 	rootCmd.AddCommand(cyclesCmd)
 	cyclesCmd.Flags().BoolVarP(&jsonOutputCycles, "json", "j", false, "Get the output in JSON format")
+	cyclesCmd.Flags().StringSliceVarP(&mainModules, "mainModules", "m", []string{}, "Enter modules whose dependencies should be considered direct dependencies; defaults to the first module encountered in `go mod graph` output")
 }


### PR DESCRIPTION
This adds the -m/--mainModules flag to the cycles command for consistency with other commands (stats, graph, diff, why).

This allows users to specify which modules to consider when detecting dependency cycles, which is needed for multi-module repositories like kubernetes/kubernetes.