### PR TITLE
Add CI integration workflows and Kubernetes-focused CLI docs

### DIFF
--- a/.github/workflows/cli-integration.yml
+++ b/.github/workflows/cli-integration.yml
@@ -1,0 +1,71 @@
+name: CLI Integration
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fixture-integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.x'
+
+      - name: Install jq
+        run: |
+          command -v jq >/dev/null 2>&1 || (sudo apt-get update && sudo apt-get install -y jq)
+
+      - name: Run deterministic fixture integration tests
+        run: make ci-fixture
+
+  kubernetes-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - name: Checkout depstat
+        uses: actions/checkout@v4
+        with:
+          path: depstat
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.x'
+
+      - name: Install jq
+        run: |
+          command -v jq >/dev/null 2>&1 || (sudo apt-get update && sudo apt-get install -y jq)
+
+      - name: Build depstat
+        working-directory: depstat
+        run: make build
+
+      - name: Checkout kubernetes
+        uses: actions/checkout@v4
+        with:
+          repository: kubernetes/kubernetes
+          path: kubernetes
+          fetch-depth: 2
+
+      - name: Run Kubernetes smoke tests
+        run: |
+          bash ./depstat/hack/ci/kubernetes-smoke.sh ./depstat/bin/depstat ./kubernetes ./depstat/_artifacts/kubernetes-smoke
+
+      - name: Upload smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: kubernetes-depstat-smoke
+          path: depstat/_artifacts/kubernetes-smoke

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,18 +5,27 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-
-  build:
+  build-and-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: [ '1.22.x', '1.23.x' ]
     steps:
     - uses: actions/checkout@v4
 
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.22'
+        go-version: ${{ matrix.go-version }}
 
     - name: Build
       run: make build
@@ -26,16 +35,16 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.22.x'
 
       - name: Run golint
         run: |
           export PATH=$PATH:$(go env GOPATH)/bin
           make lint
-

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,45 @@
-.PHONY: test
-test:
-	go test -v ./...
+DEPSTAT_BIN ?= ./bin/depstat
+K8S_DIR ?= ../k8s.io/kubernetes
+ARTIFACT_DIR ?= ./_artifacts/kubernetes-smoke
+
+.PHONY: help
+help:
+	@echo "Common targets:"
+	@echo "  make build               Build depstat binary"
+	@echo "  make test                Run unit tests"
+	@echo "  make lint                Run golangci-lint"
+	@echo "  make ci-fixture          Run deterministic CLI integration fixture"
+	@echo "  make ci-kubernetes-smoke Run CLI smoke tests against Kubernetes checkout"
+	@echo "  make clean               Remove build and artifact directories"
+	@echo ""
+	@echo "Override vars as needed:"
+	@echo "  DEPSTAT_BIN=$(DEPSTAT_BIN)"
+	@echo "  K8S_DIR=$(K8S_DIR)"
+	@echo "  ARTIFACT_DIR=$(ARTIFACT_DIR)"
 
 .PHONY: build
 build:
-	go build 
+	mkdir -p ./bin
+	go build -o $(DEPSTAT_BIN) .
+
+.PHONY: test
+test:
+	go test -v ./...
 
 .PHONY: lint
 lint:
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.2
 	golangci-lint run --verbose --enable gofmt
+
+.PHONY: ci-fixture
+ci-fixture: build
+	bash ./hack/ci/fixture-integration.sh "$(DEPSTAT_BIN)"
+
+.PHONY: ci-kubernetes-smoke
+ci-kubernetes-smoke: build
+	@test -d "$(K8S_DIR)" || { echo "K8S_DIR=$(K8S_DIR) not found"; exit 1; }
+	bash ./hack/ci/kubernetes-smoke.sh "$(DEPSTAT_BIN)" "$(K8S_DIR)" "$(ARTIFACT_DIR)"
+
+.PHONY: clean
+clean:
+	rm -rf ./bin ./_artifacts

--- a/docs/cli-kubernetes.md
+++ b/docs/cli-kubernetes.md
@@ -1,0 +1,146 @@
+# depstat CLI Guide for Kubernetes
+
+This guide shows how to run `depstat` against a real Kubernetes checkout (`k8s.io/kubernetes`), including the same patterns used in Kubernetes test-infra jobs.
+
+## Prerequisites
+
+- `go` installed (1.22+)
+- `depstat` installed:
+
+```bash
+go install github.com/kubernetes-sigs/depstat@latest
+```
+
+- Optional tools for richer output:
+```bash
+sudo apt-get update && sudo apt-get install -y jq graphviz
+```
+
+## Kubernetes Setup
+
+```bash
+export K8S_DIR=<your-kubernetes-checkout>   # e.g. ~/go/src/k8s.io/kubernetes
+cd "${K8S_DIR}"
+```
+
+**Important:** Disable Go workspaces. Kubernetes uses `replace` directives in `go.mod` to point at staging modules. With workspaces enabled, `go mod graph` resolves differently and produces incorrect results for depstat.
+
+```bash
+export GOWORK=off
+```
+
+Build the `MAIN_MODULES` list exactly like Prow jobs. This tells depstat to treat both `k8s.io/kubernetes` and all its staging modules as "main" modules (rather than external dependencies):
+
+```bash
+MAIN_MODULES="k8s.io/kubernetes$(ls staging/src/k8s.io | awk '{printf ",k8s.io/" $0}')"
+echo "${MAIN_MODULES}"
+```
+
+## Core Commands on Kubernetes
+
+### `stats`
+
+```bash
+depstat stats -m "${MAIN_MODULES}" -v
+depstat stats -m "${MAIN_MODULES}" --json > stats.json
+depstat stats -m "${MAIN_MODULES}" --csv > stats.csv
+```
+
+### `list`
+
+**Note:** `list`, `graph`, and `cycles` do not support the `--dir` flag. You must `cd` to the target directory before running them.
+
+```bash
+cd "${K8S_DIR}"
+depstat list
+```
+
+### `graph`
+
+The `graph` command always writes to `./graph.dot` in the current directory.
+
+```bash
+depstat graph -m "${MAIN_MODULES}" --show-edge-types
+dot -Tsvg graph.dot -o graph.svg
+```
+
+### `cycles`
+
+```bash
+depstat cycles -m "${MAIN_MODULES}"
+depstat cycles -m "${MAIN_MODULES}" --json > cycles.json
+```
+
+### `why`
+
+Pick a dependency and trace why it exists:
+
+```bash
+depstat why github.com/google/cel-go -m "${MAIN_MODULES}"
+depstat why github.com/google/cel-go -m "${MAIN_MODULES}" --json > why.json
+depstat why github.com/google/cel-go -m "${MAIN_MODULES}" --dot > why.dot
+depstat why github.com/google/cel-go -m "${MAIN_MODULES}" --svg > why.svg
+```
+
+### `diff`
+
+Compare dependency changes between git refs.
+
+**Warning:** The `diff` command performs `git checkout` of the base and head refs internally to analyze each snapshot. It restores the original HEAD on success, but a crash mid-operation could leave the repo in a detached HEAD state. Ensure you have no uncommitted changes before running `diff`.
+
+```bash
+BASE_SHA=$(git rev-parse HEAD~1)
+depstat diff "${BASE_SHA}" HEAD -m "${MAIN_MODULES}" -v
+depstat diff "${BASE_SHA}" HEAD -m "${MAIN_MODULES}" --json > diff.json
+depstat diff "${BASE_SHA}" HEAD -m "${MAIN_MODULES}" --dot > diff.dot
+dot -Tsvg diff.dot -o diff.svg
+```
+
+PR-style usage (matches Prow pattern):
+
+```bash
+depstat diff "${PULL_BASE_SHA}" HEAD -m "${MAIN_MODULES}" --json > diff.json
+for dep in $(jq -r '.added[]?' diff.json); do
+  depstat why "${dep}" -m "${MAIN_MODULES}" || true
+done
+```
+
+### `archived`
+
+`archived` checks if dependency source repos are archived on GitHub. It needs a token.
+
+```bash
+export GITHUB_TOKEN=<token>
+depstat archived --dir "${K8S_DIR}" --json > archived.json
+```
+
+Or use a token file:
+
+```bash
+depstat archived --dir "${K8S_DIR}" --github-token-path /etc/github/token --json > archived.json
+```
+
+## CI Mapping (Kubernetes test-infra patterns)
+
+These are the main patterns used in Kubernetes test-infra:
+
+- Periodic stats/graph/cycles generation
+- Presubmit/base-vs-head dependency diff with `why` for newly added modules
+- Archived dependency verification with `depstat archived --json`
+
+Reference files in the [kubernetes/test-infra](https://github.com/kubernetes/test-infra) repository:
+
+- [`config/jobs/kubernetes/sig-arch/kubernetes-depstat.yaml`](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-arch/kubernetes-depstat.yaml)
+- [`config/jobs/kubernetes/sig-arch/kubernetes-depstat-periodical.yaml`](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-arch/kubernetes-depstat-periodical.yaml)
+- [`experiment/dependencies/verify-archived-repos.sh`](https://github.com/kubernetes/test-infra/blob/master/experiment/dependencies/verify-archived-repos.sh)
+
+## Local Shortcuts in This Repo
+
+From this repository (`sigs.k8s.io/depstat`), the Makefile includes:
+
+```bash
+make ci-fixture
+make ci-kubernetes-smoke K8S_DIR=<your-kubernetes-checkout>
+```
+
+`ci-kubernetes-smoke` runs `stats`, `list`, `graph`, `cycles`, `why`, and `diff` against your Kubernetes checkout and saves artifacts.

--- a/hack/ci/fixture-integration.sh
+++ b/hack/ci/fixture-integration.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DEPSTAT_BIN="${1:-}"
+if [[ -z "${DEPSTAT_BIN}" ]]; then
+  echo "usage: $0 <depstat-binary>"
+  exit 1
+fi
+DEPSTAT_BIN="$(cd "$(dirname "${DEPSTAT_BIN}")" && pwd)/$(basename "${DEPSTAT_BIN}")"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required"
+  exit 1
+fi
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+mkdir -p "${workdir}/"{root,a,b,c,d,e}
+
+cat >"${workdir}/root/go.mod" <<'EOF'
+module example.com/root
+
+go 1.22
+
+require (
+	example.com/a v0.0.0
+	example.com/b v0.0.0
+)
+
+replace (
+	example.com/a => ../a
+	example.com/b => ../b
+	example.com/c => ../c
+	example.com/d => ../d
+	example.com/e => ../e
+)
+EOF
+
+cat >"${workdir}/a/go.mod" <<'EOF'
+module example.com/a
+
+go 1.22
+
+require example.com/c v0.0.0
+
+replace example.com/c => ../c
+EOF
+
+cat >"${workdir}/b/go.mod" <<'EOF'
+module example.com/b
+
+go 1.22
+
+require example.com/d v0.0.0
+
+replace example.com/d => ../d
+EOF
+
+cat >"${workdir}/c/go.mod" <<'EOF'
+module example.com/c
+
+go 1.22
+
+require example.com/a v0.0.0
+
+replace example.com/a => ../a
+EOF
+
+cat >"${workdir}/d/go.mod" <<'EOF'
+module example.com/d
+
+go 1.22
+EOF
+
+cat >"${workdir}/e/go.mod" <<'EOF'
+module example.com/e
+
+go 1.22
+EOF
+
+for m in root a b c d e; do
+  cat >"${workdir}/${m}/dummy.go" <<EOF
+package ${m}
+EOF
+done
+
+pushd "${workdir}/root" >/dev/null
+
+git init -q
+git config user.name "depstat-ci"
+git config user.email "depstat-ci@example.com"
+git add .
+git commit -q -m "initial fixture graph"
+
+echo "==> Testing stats --json..."
+"${DEPSTAT_BIN}" stats --json > stats.json
+jq -e '.directDependencies >= 2 and .transitiveDependencies >= 1 and .totalDependencies >= 3 and .maxDepthOfDependencies >= 2' stats.json >/dev/null \
+  || { echo "FAIL: stats JSON field values out of range"; exit 1; }
+
+echo "==> Testing stats --csv..."
+"${DEPSTAT_BIN}" stats --csv > stats.csv
+grep -q '^Direct,Transitive,Total,MaxDepth$' stats.csv \
+  || { echo "FAIL: stats CSV missing expected header"; exit 1; }
+
+echo "==> Testing list..."
+"${DEPSTAT_BIN}" list > list.txt
+grep -q '^example.com/a$' list.txt \
+  || { echo "FAIL: list missing example.com/a"; exit 1; }
+grep -q '^example.com/c$' list.txt \
+  || { echo "FAIL: list missing example.com/c"; exit 1; }
+
+echo "==> Testing graph --show-edge-types..."
+"${DEPSTAT_BIN}" graph --show-edge-types
+[[ -s graph.dot ]] \
+  || { echo "FAIL: graph.dot is empty or missing"; exit 1; }
+grep -q 'edgetype="direct"' graph.dot \
+  || { echo "FAIL: graph.dot missing direct edges"; exit 1; }
+grep -q 'edgetype="transitive"' graph.dot \
+  || { echo "FAIL: graph.dot missing transitive edges"; exit 1; }
+
+echo "==> Testing cycles --json..."
+"${DEPSTAT_BIN}" cycles --json > cycles.json
+jq -e '.cycles != null' cycles.json >/dev/null \
+  || { echo "FAIL: cycles JSON missing .cycles key"; exit 1; }
+
+echo "==> Testing why --json..."
+"${DEPSTAT_BIN}" why example.com/c --json > why.json
+jq -e '.target == "example.com/c" and .found == true and (.paths | length >= 1)' why.json >/dev/null \
+  || { echo "FAIL: why JSON check failed for example.com/c"; exit 1; }
+
+echo "==> Testing why --dot..."
+"${DEPSTAT_BIN}" why example.com/c --dot > why.dot
+grep -q 'strict digraph' why.dot \
+  || { echo "FAIL: why --dot output missing 'strict digraph'"; exit 1; }
+
+echo "==> Testing why --svg..."
+"${DEPSTAT_BIN}" why example.com/c --svg > why.svg
+grep -q '<svg' why.svg \
+  || { echo "FAIL: why --svg output missing '<svg' tag"; exit 1; }
+
+echo "==> Testing completion..."
+"${DEPSTAT_BIN}" completion bash > /dev/null \
+  || { echo "FAIL: completion bash failed"; exit 1; }
+
+echo "==> Preparing diff fixture (adding dependency e)..."
+awk '
+/^require \($/ {print; print "\texample.com/e v0.0.0"; inreq=1; next}
+/^\)$/ && inreq {inreq=0}
+{print}
+' go.mod > go.mod.new
+mv go.mod.new go.mod
+git add go.mod
+git commit -q -m "add dependency e"
+
+echo "==> Testing diff --json..."
+"${DEPSTAT_BIN}" diff HEAD~1 HEAD --json > diff.json
+jq -e 'has("before") and has("after") and has("delta")' diff.json >/dev/null \
+  || { echo "FAIL: diff JSON missing expected keys"; exit 1; }
+
+echo "==> Testing diff --dot..."
+"${DEPSTAT_BIN}" diff HEAD~1 HEAD --dot > diff.dot
+grep -q 'strict digraph' diff.dot \
+  || { echo "FAIL: diff --dot output missing 'strict digraph'"; exit 1; }
+
+echo "==> Testing diff-then-why loop (Prow presubmit pattern)..."
+for dep in $(jq -r '.added[]?' diff.json); do
+  "${DEPSTAT_BIN}" why "${dep}" --json > /dev/null || true
+done
+
+popd >/dev/null
+
+echo "fixture integration checks passed"

--- a/hack/ci/kubernetes-smoke.sh
+++ b/hack/ci/kubernetes-smoke.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DEPSTAT_BIN="${1:-}"
+K8S_DIR="${2:-}"
+ARTIFACT_DIR="${3:-}"
+
+if [[ -z "${DEPSTAT_BIN}" || -z "${K8S_DIR}" ]]; then
+  echo "usage: $0 <depstat-binary> <kubernetes-dir> [artifact-dir]"
+  exit 1
+fi
+DEPSTAT_BIN="$(cd "$(dirname "${DEPSTAT_BIN}")" && pwd)/$(basename "${DEPSTAT_BIN}")"
+K8S_DIR="$(cd "${K8S_DIR}" && pwd)"
+
+if [[ -z "${ARTIFACT_DIR}" ]]; then
+  ARTIFACT_DIR="$(pwd)/_artifacts/kubernetes-smoke"
+fi
+ARTIFACT_DIR="$(mkdir -p "${ARTIFACT_DIR}" && cd "${ARTIFACT_DIR}" && pwd)"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required"
+  exit 1
+fi
+
+pushd "${K8S_DIR}" >/dev/null
+export GOWORK=off
+
+[[ -d staging/src/k8s.io ]] \
+  || { echo "FATAL: staging/src/k8s.io not found in ${K8S_DIR}"; exit 1; }
+
+main_modules="k8s.io/kubernetes$(ls staging/src/k8s.io | awk '{printf ",k8s.io/" $0}')"
+start_ref="$(git rev-parse HEAD)"
+base_ref="$(git rev-parse HEAD~1)"
+
+echo "==> Testing stats (verbose, json, csv)..."
+"${DEPSTAT_BIN}" stats -m "${main_modules}" -v > "${ARTIFACT_DIR}/stats.txt"
+"${DEPSTAT_BIN}" stats -m "${main_modules}" --json > "${ARTIFACT_DIR}/stats.json"
+"${DEPSTAT_BIN}" stats -m "${main_modules}" --csv > "${ARTIFACT_DIR}/stats.csv"
+jq -e '.directDependencies >= 1 and .totalDependencies >= .directDependencies and .maxDepthOfDependencies >= 1' "${ARTIFACT_DIR}/stats.json" >/dev/null \
+  || { echo "FAIL: stats JSON field values out of range"; exit 1; }
+grep -q '^Direct,Transitive,Total,MaxDepth$' "${ARTIFACT_DIR}/stats.csv" \
+  || { echo "FAIL: stats CSV missing expected header"; exit 1; }
+
+echo "==> Testing list..."
+"${DEPSTAT_BIN}" list > "${ARTIFACT_DIR}/list.txt"
+
+echo "==> Testing graph --show-edge-types..."
+"${DEPSTAT_BIN}" graph -m "${main_modules}" --show-edge-types
+mv graph.dot "${ARTIFACT_DIR}/graph.dot"
+grep -q 'edgetype="direct"' "${ARTIFACT_DIR}/graph.dot" \
+  || { echo "FAIL: graph.dot missing direct edges"; exit 1; }
+
+echo "==> Testing cycles --json..."
+"${DEPSTAT_BIN}" cycles -m "${main_modules}" --json > "${ARTIFACT_DIR}/cycles.json"
+jq -e '.cycles != null' "${ARTIFACT_DIR}/cycles.json" >/dev/null \
+  || { echo "FAIL: cycles JSON missing .cycles key"; exit 1; }
+
+echo "==> Testing why (dynamic target)..."
+# Pick a non-main dependency namespace. k8s.io/* entries are often main modules
+# when -m includes staging modules, which makes "why" report found=false.
+target_dep="$("${DEPSTAT_BIN}" list | awk '/^(github.com|golang.org)\// {print; exit}')" || true
+if [[ -n "${target_dep}" ]]; then
+  "${DEPSTAT_BIN}" why "${target_dep}" -m "${main_modules}" --json > "${ARTIFACT_DIR}/why.json"
+  jq -e '.target == "'"${target_dep}"'" and .found == true' "${ARTIFACT_DIR}/why.json" >/dev/null \
+    || { echo "FAIL: why JSON check failed for ${target_dep}"; exit 1; }
+else
+  echo "WARNING: could not determine a target dependency for 'why' test, skipping"
+fi
+
+echo "==> Testing diff --json and --dot..."
+"${DEPSTAT_BIN}" diff "${base_ref}" HEAD -m "${main_modules}" --json > "${ARTIFACT_DIR}/diff.json"
+"${DEPSTAT_BIN}" diff "${base_ref}" HEAD -m "${main_modules}" --dot > "${ARTIFACT_DIR}/diff.dot"
+jq -e 'has("before") and has("after") and has("delta") and has("added") and has("removed")' "${ARTIFACT_DIR}/diff.json" >/dev/null \
+  || { echo "FAIL: diff JSON missing expected keys"; exit 1; }
+grep -q 'strict digraph' "${ARTIFACT_DIR}/diff.dot" \
+  || { echo "FAIL: diff --dot output missing 'strict digraph'"; exit 1; }
+
+echo "==> Verifying HEAD was restored after diff..."
+end_ref="$(git rev-parse HEAD)"
+if [[ "${start_ref}" != "${end_ref}" ]]; then
+  echo "FAIL: depstat diff did not restore HEAD (start=${start_ref}, end=${end_ref})"
+  exit 1
+fi
+
+popd >/dev/null
+
+echo "kubernetes smoke checks passed"


### PR DESCRIPTION
Add two-tier CI testing (deterministic fixture + real Kubernetes smoke) and comprehensive CLI documentation for Kubernetes workflows.

CI integration (hack/ci/):
- fixture-integration.sh: test stats (json/csv), list, graph, cycles, why (json/dot/svg), diff (json/dot), completion, and the Prow-style diff-then-why loop, with descriptive failure messages and progress logging
- kubernetes-smoke.sh: test against real k8s.io/kubernetes checkout with GOWORK=off, staging directory guard, depstat-list-based target selection for why tests, and HEAD-restoration safety check after diff

Workflows (.github/workflows/):
- cli-integration.yml: fixture + kubernetes-smoke jobs with concurrency control, jq install, and artifact upload on failure
- go.yml: add timeouts, concurrency group, and workflow_dispatch trigger

Makefile: add ci-fixture, ci-kubernetes-smoke, clean targets with help text and K8S_DIR existence guard

Documentation:
- docs/cli-kubernetes.md: full guide for running depstat against Kubernetes including GOWORK=off rationale, MAIN_MODULES setup, all commands with examples, diff git-checkout warning, and links to test-infra Prow jobs
- README.md: add Quick Start section, clickable docs link, and --mainModules concept explanation