### PR TITLE
Add --split-test-only flag to list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This guide mirrors the patterns used in Kubernetes test-infra Prow jobs.
 Run `depstat help` for full command help.
 
 - `depstat stats`: dependency counts and maximum depth (`--json`, `--csv`, `--verbose`, `--split-test-only`, `--mainModules`, `--dir`)
-- `depstat list`: sorted list of all dependencies in the current module
+- `depstat list`: sorted list of all dependencies in the current module (`--split-test-only`)
 - `depstat graph`: write `graph.dot` (`--dep`, `--show-edge-types`, `--mainModules`)
 - `depstat cycles`: detect dependency cycles (`--json`, `--mainModules`)
 - `depstat why <dependency>`: explain why a dependency is present (`--json`, `--dot`, `--svg`, `--mainModules`, `--dir`)

--- a/docs/cli-kubernetes.md
+++ b/docs/cli-kubernetes.md
@@ -54,6 +54,7 @@ depstat stats -m "${MAIN_MODULES}" --split-test-only --json > stats-split.json
 ```bash
 cd "${K8S_DIR}"
 depstat list
+depstat list --split-test-only
 ```
 
 ### `graph`

--- a/hack/ci/fixture-integration.sh
+++ b/hack/ci/fixture-integration.sh
@@ -229,6 +229,15 @@ echo "==> Testing stats --split-test-only --json..."
 jq -e '.testOnlyDependencies >= 1 and .nonTestOnlyDependencies >= 1' stats-split.json >/dev/null \
   || { echo "FAIL: stats --split-test-only did not report expected test/non-test counts"; exit 1; }
 
+echo "==> Testing list --split-test-only..."
+"${DEPSTAT_BIN}" list --split-test-only > list-split.txt
+grep -q 'Non-test dependencies' list-split.txt \
+  || { echo "FAIL: list --split-test-only missing non-test section"; exit 1; }
+grep -q 'Test-only dependencies' list-split.txt \
+  || { echo "FAIL: list --split-test-only missing test-only section"; exit 1; }
+grep -q 'example.com/t' list-split.txt \
+  || { echo "FAIL: list --split-test-only missing example.com/t"; exit 1; }
+
 echo "==> Testing diff --split-test-only --json..."
 "${DEPSTAT_BIN}" diff HEAD~1 HEAD --split-test-only --json > diff-split.json
 jq -e '.split != null' diff-split.json >/dev/null \


### PR DESCRIPTION
Split the dependency list into non-test and test-only sections using `go mod why -m` to classify each dependency.

  depstat list --split-test-only

Addresses kubernetes-sigs/depstat#68