### PR TITLE
harden archived resolution and align CLI output/flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ This guide mirrors the patterns used in Kubernetes test-infra Prow jobs.
 Run `depstat help` for full command help.
 
 - `depstat stats`: dependency counts and maximum depth (`--json`, `--csv`, `--verbose`, `--split-test-only`, `--mainModules`, `--dir`)
-- `depstat list`: sorted list of all dependencies in the current module (`--split-test-only`)
-- `depstat graph`: write `graph.dot` (`--dep`, `--show-edge-types`, `--mainModules`)
-- `depstat cycles`: detect dependency cycles (`--json`, `--mainModules`)
+- `depstat list`: sorted list of all dependencies in the current module (`--json`, `--split-test-only`, `--mainModules`, `--dir`)
+- `depstat graph`: dependency graph (`--dot`, `--json`, `--output`, `--dep`, `--show-edge-types`, `--mainModules`)
+- `depstat cycles`: detect dependency cycles (`--json`, `--mainModules`, `--dir`)
 - `depstat why <dependency>`: explain why a dependency is present (`--json`, `--dot`, `--svg`, `--mainModules`, `--dir`)
 - `depstat diff <base-ref> [head-ref]`: compare dependency changes between git refs (`--json`, `--dot`, `--verbose`, `--split-test-only`, `--vendor`, `--vendor-files`, `--mainModules`, `--dir`)
 - `depstat archived`: detect archived upstream GitHub repositories (`--json`, `--github-token-path`, `--dir`)

--- a/cmd/archived_test.go
+++ b/cmd/archived_test.go
@@ -1,0 +1,35 @@
+package cmd
+
+import "testing"
+
+func TestResolveRepoFromGoImport(t *testing.T) {
+	body := `<html><head>
+<meta name="go-import" content="k8s.io/klog git https://github.com/kubernetes/klog.git">
+</head></html>`
+	got := resolveRepoFromGoImport(body, "k8s.io/klog/v2")
+	if got != "kubernetes/klog" {
+		t.Fatalf("expected kubernetes/klog, got %q", got)
+	}
+}
+
+func TestResolveRepoFromGoImportMostSpecificPrefix(t *testing.T) {
+	body := `<html><head>
+<meta name="go-import" content="example.com git https://github.com/acme/root">
+<meta name="go-import" content="example.com/sub git https://github.com/acme/subrepo">
+</head></html>`
+	got := resolveRepoFromGoImport(body, "example.com/sub/pkg")
+	if got != "acme/subrepo" {
+		t.Fatalf("expected acme/subrepo, got %q", got)
+	}
+}
+
+func TestResolveRepoFromGoImportIgnoresNonMatchingOrNonGit(t *testing.T) {
+	body := `<html><head>
+<meta name="go-import" content="example.com hg https://github.com/acme/wrong-vcs">
+<meta name="go-import" content="other.io/mod git https://github.com/acme/other">
+</head></html>`
+	got := resolveRepoFromGoImport(body, "example.com/mod")
+	if got != "" {
+		t.Fatalf("expected empty repo, got %q", got)
+	}
+}

--- a/cmd/cycles.go
+++ b/cmd/cycles.go
@@ -299,6 +299,7 @@ func containsInt(slice []int, val int) bool {
 
 func init() {
 	rootCmd.AddCommand(cyclesCmd)
+	cyclesCmd.Flags().StringVarP(&dir, "dir", "d", "", "Directory containing the module to evaluate. Defaults to the current directory.")
 	cyclesCmd.Flags().BoolVarP(&jsonOutputCycles, "json", "j", false, "Get the output in JSON format")
 	cyclesCmd.Flags().StringSliceVarP(&mainModules, "mainModules", "m", []string{}, "Enter modules whose dependencies should be considered direct dependencies; defaults to the first module encountered in `go mod graph` output")
 }


### PR DESCRIPTION
## Summary
- archived: handle non-2xx GraphQL responses explicitly
- archived: resolve vanity modules via go-import meta parsing with prefix matching
- list: add `--dir`, `--mainModules`, and `--json`
- cycles: add `--dir`
- graph: add `--dot`, `--json`, and `--output`
- update README command docs

## Validation
- go test ./...
- smoke-tested list/cycles/graph/archived across containerd, etcd, kubernetes