### PR TITLE
finish remaining UX consistency gaps in diff/graph/archived

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ Run `depstat help` for full command help.
 
 - `depstat stats`: dependency counts and maximum depth (`--json`, `--csv`, `--verbose`, `--split-test-only`, `--mainModules`, `--dir`)
 - `depstat list`: sorted list of all dependencies in the current module (`--json`, `--split-test-only`, `--mainModules`, `--dir`)
-- `depstat graph`: dependency graph (`--dot`, `--json`, `--output`, `--dep`, `--show-edge-types`, `--mainModules`)
+- `depstat graph`: dependency graph (`--dot`, `--json`, `--output`, `--dep`/`-p`, `--show-edge-types`, `--mainModules`, `--dir`)
 - `depstat cycles`: detect dependency cycles (`--json`, `--mainModules`, `--dir`)
 - `depstat why <dependency>`: explain why a dependency is present (`--json`, `--dot`, `--svg`, `--mainModules`, `--dir`)
-- `depstat diff <base-ref> [head-ref]`: compare dependency changes between git refs (`--json`, `--dot`, `--verbose`, `--split-test-only`, `--vendor`, `--vendor-files`, `--mainModules`, `--dir`)
-- `depstat archived`: detect archived upstream GitHub repositories (`--json`, `--github-token-path`, `--dir`)
+- `depstat diff <base-ref> [head-ref]`: compare dependency changes between git refs (`--json`, `--dot`, `--svg`, `--verbose`, `--split-test-only`, `--vendor`, `--vendor-files`, `--mainModules`, `--dir`)
+- `depstat archived`: detect archived upstream GitHub repositories (`--json`, `--github-token-path`, `--mainModules`, `--dir`)
 - `depstat completion [bash|zsh|fish|powershell]`
 
 The `--mainModules` / `-m` flag accepts a comma-separated list of module names to treat as "main" modules. This is essential for multi-module repositories like Kubernetes, where both the root module and all staging modules should be treated as first-party code rather than external dependencies. Without `-m`, depstat auto-detects a single main module from `go list -m`.

--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -131,7 +131,7 @@ func getAllChains(currentDep string, graph map[string][]string, currentChain Cha
 }
 
 // get the contents of the .dot file for the graph
-// when the -d flag is set
+// when the --dep flag is set
 func getFileContentsForSingleDep(chains []Chain, dep string) string {
 	// to color the entered node as yellow
 	data := colorMainNode(dep)
@@ -154,7 +154,7 @@ func getFileContentsForSingleDep(chains []Chain, dep string) string {
 }
 
 // get the contents of the .dot file for the graph
-// of all dependencies (when -d is not set)
+// of all dependencies (when --dep is not set)
 func getFileContentsForAllDeps(overview *DependencyOverview) string {
 	return getFileContentsForAllDepsWithTypes(overview, false)
 }
@@ -227,7 +227,8 @@ func colorMainNode(mainNode string) string {
 
 func init() {
 	rootCmd.AddCommand(graphCmd)
-	graphCmd.Flags().StringVarP(&dep, "dep", "d", "", "Specify dependency to create a graph around")
+	graphCmd.Flags().StringVarP(&dir, "dir", "d", "", "Directory containing the module to evaluate. Defaults to the current directory.")
+	graphCmd.Flags().StringVarP(&dep, "dep", "p", "", "Specify dependency to create a graph around")
 	graphCmd.Flags().BoolVar(&showEdgeTypes, "show-edge-types", false, "Distinguish direct vs transitive edges with colors/styles")
 	graphCmd.Flags().BoolVar(&graphDotOutput, "dot", false, "Output DOT graph to stdout")
 	graphCmd.Flags().BoolVarP(&graphJSONOutput, "json", "j", false, "Output graph data in JSON format")


### PR DESCRIPTION
## Summary
- add `depstat diff --svg` output mode (Graphviz-backed rendering)
- add `depstat archived --mainModules` filtering support
- normalize graph flag semantics:
  - add `graph --dir/-d`
  - move `graph --dep` shorthand to `-p` (so `-d` consistently means directory)
- update README command flag docs

## Validation
- `go test ./...`
- `depstat diff HEAD~1 HEAD --dir <repo> --svg` emits SVG
- `depstat graph --help` shows `--dir/-d` and `--dep/-p`
- `depstat archived --dir <repo> --mainModules <module> --github-token-path /tmp/gh-token --json` works on etcd

## Notes
This closes the remaining `PARTIAL` items from the UX issues tracker for output/flag consistency except broader command-relationship docs cleanup.