### PR TITLE
Fix depstat why path search for large graphs

### DIFF
--- a/cmd/why_test.go
+++ b/cmd/why_test.go
@@ -14,8 +14,9 @@ func TestFindAllPathsHonorsLimit(t *testing.T) {
 		"B": {"D"},
 		"C": {"D"},
 	}
+	reachable := map[string]bool{"A": true, "B": true, "C": true, "D": true}
 	var out [][]string
-	findAllPaths("A", "D", graph, []string{}, map[string]bool{}, &out, 1)
+	findAllPaths("A", "D", graph, reachable, []string{}, map[string]bool{}, &out, 1)
 	if len(out) != 1 {
 		t.Fatalf("expected exactly 1 path due to limit, got %d (%v)", len(out), out)
 	}


### PR DESCRIPTION
## Summary
- prune why-path DFS using reverse reachability to avoid full-graph traversal
- correct per-main-module max-paths accounting
- update why tests for new signature

## Issue
`depstat why go.etcd.io/raft/v3` in the etcd repo would hang / produce no output even though the dependency exists. The search walked the full graph instead of pruning to nodes that can reach the target.

## Fix
Precompute reverse reachability and only traverse nodes that can reach the target. This makes `why` complete quickly for large graphs and returns valid path output.

## Testing
- go test ./...